### PR TITLE
fix: default includedInDataCatalog to portal URL

### DIFF
--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -125,7 +125,8 @@ module LinkedData
       attribute :source, namespace: :dct, type: :list
       attribute :endpoint, namespace: :sd, type: %i[uri list],
                            default: ->(s) { default_sparql_endpoint(s) }
-      attribute :includedInDataCatalog, namespace: :schema, type: %i[list uri]
+      attribute :includedInDataCatalog, namespace: :schema, type: %i[list uri],
+                           default: ->(_s) { [RDF::URI.new("https://#{LinkedData.settings.ui_host}")] }
 
       # Relations
       attribute :hasPriorVersion, namespace: :omv, type: :uri


### PR DESCRIPTION
### Summary
- Add default value for includedInDataCatalog attribute on new ontology submissions
- Default is set to `https://<ui_host>` using LinkedData.settings.ui_host config


Closes #18 

### Test
Create a new ontology submission without setting includedInDataCatalog
Verify the field is automatically populated with the portal URL
