### PR TITLE
feat: add editWith metadata property to ontology submission

### DIFF
--- a/config/schemes/ontology_submission.yml
+++ b/config/schemes/ontology_submission.yml
@@ -868,6 +868,16 @@ wasInvalidatedBy:
   extractedMetadata: true
   metadataMappings: [ "prov:wasInvalidatedBy" ]
 
+#Edit with
+editWith:
+  display: "methodology"
+  label: "Edit with"
+  helpText: "URL of the external editor used to edit the content of this ontology (e.g. OpenTheso, VocBench)."
+  example: 'https://stage.earthportal.eu/opentheso'
+  description: [
+    "The URL of the external editor used to edit the content (concepts) of this semantic artefact." ]
+  extractedMetadata: false
+
 ### Object description properties
 
 #Object preferred label property

--- a/config/schemes/ontology_submission.yml
+++ b/config/schemes/ontology_submission.yml
@@ -875,7 +875,7 @@ editWith:
   helpText: "URL of the external editor used to edit the content of this ontology (e.g. OpenTheso, VocBench)."
   example: 'https://stage.earthportal.eu/opentheso'
   description: [
-    "The URL of the external editor used to edit the content (concepts) of this semantic artefact." ]
+    "The URL of the external editor used to edit the content of this semantic artefact." ]
   extractedMetadata: false
 
 ### Object description properties

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -113,7 +113,7 @@ module LinkedData
       attribute :competencyQuestion, namespace: :mod, type: :list
       attribute :wasGeneratedBy, namespace: :prov, type: :list
       attribute :wasInvalidatedBy, namespace: :prov, type: :list
-      attribute :editWith, namespace: :metadata_def, type: :uri
+      attribute :editWith, namespace: :metadata, type: :uri
 
       # Links
       attribute :pullLocation, type: :uri # URI for pulling ontology

--- a/lib/ontologies_linked_data/models/ontology_submission.rb
+++ b/lib/ontologies_linked_data/models/ontology_submission.rb
@@ -113,6 +113,7 @@ module LinkedData
       attribute :competencyQuestion, namespace: :mod, type: :list
       attribute :wasGeneratedBy, namespace: :prov, type: :list
       attribute :wasInvalidatedBy, namespace: :prov, type: :list
+      attribute :editWith, namespace: :metadata_def, type: :uri
 
       # Links
       attribute :pullLocation, type: :uri # URI for pulling ontology


### PR DESCRIPTION
Adds an `editWith` property to ontology submissions, storing the URL of the external editor used to edit the ontology content like OpenTheso.

- Declare `editWith` attribute (`metadata`, type `uri`) in the model
- Add its scheme entry (label, help text, example) in the config